### PR TITLE
PR for fix to include new logic for output trimming 

### DIFF
--- a/FulcrumInjector/FulcrumLogic/ExtensionClasses/ExpressionExtensions.cs
+++ b/FulcrumInjector/FulcrumLogic/ExtensionClasses/ExpressionExtensions.cs
@@ -67,7 +67,7 @@ namespace FulcrumInjector.FulcrumLogic.ExtensionClasses
         /// </summary>
         /// <param name="InputExpressions">Expression input objects</param>
         /// <returns>Path of our built expression file</returns>
-        public static string SaveExpressionsToFile(this PassThruExpression[] InputExpressions, string BaseFileName = "")
+        public static string SaveExpressionsFile(this PassThruExpression[] InputExpressions, string BaseFileName = "")
         {
             // Get a logger object for saving expression sets.
             var ExpressionLogger = (SubServiceLogger)LogBroker.LoggerQueue.GetLoggers(LoggerActions.SubServiceLogger)
@@ -75,9 +75,11 @@ namespace FulcrumInjector.FulcrumLogic.ExtensionClasses
 
             // First build our output location for our file.
             string OutputFolder = Path.Combine(LogBroker.BaseOutputPath, "FulcrumExpressions");
-            string FinalOutputPath = 
-                BaseFileName.Contains(Path.DirectorySeparatorChar) ? 
-                    Path.ChangeExtension(BaseFileName, "ptExp") : 
+            string FinalOutputPath =
+                BaseFileName.Contains(Path.DirectorySeparatorChar) ?
+                    Path.ChangeExtension(Path.Combine(
+                        Path.GetDirectoryName(BaseFileName), $"FulcrumExpressions_{Path.GetFileName(BaseFileName)}"),
+                "ptExp") :
                     BaseFileName.Length == 0 ? 
                         Path.Combine(OutputFolder, $"FulcrumExpressions_{DateTime.Now:MMddyyyy-HHmmss}.ptExp") : 
                         Path.Combine(OutputFolder, $"FulcrumExpressions_{Path.GetFileNameWithoutExtension(BaseFileName)}.ptExp");

--- a/FulcrumInjector/FulcrumViewContent/ViewModels/InjectorCoreViewModels/FulcrumDllOutputLogViewModel.cs
+++ b/FulcrumInjector/FulcrumViewContent/ViewModels/InjectorCoreViewModels/FulcrumDllOutputLogViewModel.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
 using FulcrumInjector.FulcrumViewContent.Views.InjectorCoreViews;
 using FulcrumInjector.FulcrumViewSupport;
 using FulcrumInjector.FulcrumViewSupport.AvalonEditHelpers;
@@ -18,14 +20,15 @@ namespace FulcrumInjector.FulcrumViewContent.ViewModels.InjectorCoreViewModels
         private bool _hasOutput;
         private bool _usingRegex;
         private bool _noResultsOnSearch;
-        
+        private string[] _sessionLogs;
+
         // Public values for our view to bind onto 
         public bool HasOutput { get => _hasOutput; set => PropertyUpdated(value); }
         public bool UsingRegex { get => _usingRegex; set => PropertyUpdated(value); }
+        public string[] SessionLogs { get => _sessionLogs; set => PropertyUpdated(value); }
         public bool NoResultsOnSearch { get => _noResultsOnSearch; set => PropertyUpdated(value); }
 
         // Helper for editing Text box contents
-        private readonly PropertyWatchdog _outputWatchdog;
         public AvalonEditFilteringHelpers LogContentHelper;
 
         // --------------------------------------------------------------------------------------------------------------------------
@@ -38,6 +41,10 @@ namespace FulcrumInjector.FulcrumViewContent.ViewModels.InjectorCoreViewModels
             // Log information and store values 
             ViewModelLogger.WriteLog($"VIEWMODEL LOGGER FOR VM {this.GetType().Name} HAS BEEN STARTED OK!", LogType.InfoLog);
             ViewModelLogger.WriteLog("SETTING UP INJECTOR TEST VIEW BOUND VALUES NOW...", LogType.WarnLog);
+
+            // Build default value for session log files.
+            ViewModelLogger.WriteLog("BUILDING EMPTY ARRAY FOR SESSION LOG FILES NOW...", LogType.WarnLog);
+            this.SessionLogs = Array.Empty<string>();
 
             // Build log content helper and return
             ViewModelLogger.WriteLog("SETUP NEW DLL INJECTION OUTPUT LOG VALUES OK!", LogType.InfoLog);

--- a/FulcrumInjector/FulcrumViewContent/ViewModels/InjectorCoreViewModels/FulcrumLogReviewViewModel.cs
+++ b/FulcrumInjector/FulcrumViewContent/ViewModels/InjectorCoreViewModels/FulcrumLogReviewViewModel.cs
@@ -125,15 +125,15 @@ namespace FulcrumInjector.FulcrumViewContent.ViewModels.InjectorCoreViewModels
         /// <returns></returns>
         internal bool ParseLogContents(out ObservableCollection<PassThruExpression> OutputExpressions)
         {
-            // Build command split log contents first. 
             try
             {
+                // Build command split log contents first. 
                 ViewModelLogger.WriteLog("PROCESSING LOG LINES INTO EXPRESSIONS NOW...", LogType.InfoLog);
                 var SplitLogContent = this.SplitLogToCommands(LogFileContents);
                 ViewModelLogger.WriteLog($"SPLIT CONTENTS INTO A TOTAL OF {SplitLogContent.Length} CONTENT SET OBJECTS", LogType.WarnLog);
 
                 // Start by building PTExpressions from input string object sets.
-                ViewModelLogger.WriteLog("PROCESSING LOG LINES INTO PTEXPRESSION OBJECTS FOR BINDING NOW...", LogType.InfoLog);
+                ViewModelLogger.WriteLog("PROCESSING LOG LINES INTO PT EXPRESSION OBJECTS FOR BINDING NOW...", LogType.InfoLog);
                 var ExpressionSet = SplitLogContent.Select(LineSet =>
                 {
                     // Split our output content here and then build a type for the expressions
@@ -149,11 +149,10 @@ namespace FulcrumInjector.FulcrumViewContent.ViewModels.InjectorCoreViewModels
                 }).ToArray();
 
                 // Convert the expression set into a list of file strings now and return list built.
-                this._lastBuiltExpressionsFile = ExpressionSet.SaveExpressionsToFile(Path.GetFileName(LoadedLogFile));
+                this._lastBuiltExpressionsFile = ExpressionSet.SaveExpressionsFile(this.LoadedLogFile);
                 ViewModelLogger.WriteLog($"GENERATED A TOTAL OF {ExpressionSet.Length} EXPRESSION OBJECTS!", LogType.InfoLog);
                 ViewModelLogger.WriteLog($"SAVED EXPRESSIONS TO NEW FILE OBJECT NAMED: {this._lastBuiltExpressionsFile}!", LogType.InfoLog);
-                OutputExpressions = new ObservableCollection<PassThruExpression>(ExpressionSet);
-                this.InputParsed = true;
+                OutputExpressions = new ObservableCollection<PassThruExpression>(ExpressionSet); this.InputParsed = true;
                 return true;
             }
             catch (Exception Ex)
@@ -161,8 +160,7 @@ namespace FulcrumInjector.FulcrumViewContent.ViewModels.InjectorCoreViewModels
                 // Log failures, return nothing
                 ViewModelLogger.WriteLog("FAILED TO GENERATE NEW EXPRESSION SETUP FROM INPUT CONTENT!", LogType.ErrorLog);
                 ViewModelLogger.WriteLog("EXCEPTION IS BEING LOGGED BELOW", Ex);
-                OutputExpressions = null;
-                this.InputParsed = false;
+                OutputExpressions = null; this.InputParsed = false;
                 return false;
             }
         }

--- a/FulcrumInjector/FulcrumViewContent/Views/InjectorCoreViews/FulcrumDllOutputLogView.xaml.cs
+++ b/FulcrumInjector/FulcrumViewContent/Views/InjectorCoreViews/FulcrumDllOutputLogView.xaml.cs
@@ -41,8 +41,17 @@ namespace FulcrumInjector.FulcrumViewContent.Views.InjectorCoreViews
             // TODO: Append new Transformers into this constructor to apply color filtering on the output view.
 
             // Build event for our pipe objects to process new pipe content into our output box
-            FulcrumPipeReader.PipeInstance.PipeDataProcessed += (_, EventArgs) => {
+            FulcrumPipeReader.PipeInstance.PipeDataProcessed += (_, EventArgs) => 
+            {
+                // Attach output content into our session log box.
                 Dispatcher.Invoke(() => { this.DebugRedirectOutputEdit.Text += EventArgs.PipeDataString + "\n"; });
+                if (!EventArgs.PipeDataString.Contains("Session Log File:")) return;
+
+                // Store log file object name onto our injector constants here.
+                string NextSessionLog = string.Join("", EventArgs.PipeDataString.Split(':').Skip(1));
+                ViewLogger.WriteLog("STORING NEW FILE NAME VALUE INTO STORE OBJECT FOR REGISTERED OUTPUT FILES!", LogType.WarnLog);
+                ViewLogger.WriteLog($"SESSION LOG FILE BEING APPENDED APPEARED TO HAVE NAME OF {NextSessionLog}", LogType.InfoLog);
+                this.ViewModel.SessionLogs = this.ViewModel.SessionLogs.Append(NextSessionLog).ToArray();
             };
         }
 

--- a/FulcrumInjector/FulcrumViewContent/Views/InjectorOptionViews/FulcrumDebugLoggingView.xaml
+++ b/FulcrumInjector/FulcrumViewContent/Views/InjectorOptionViews/FulcrumDebugLoggingView.xaml
@@ -48,7 +48,7 @@
                 <TextBlock 
                     Grid.Row="0"
                     Margin="10,0"
-                    Text="Injector DLL Output" 
+                    Text="Injector Debug Logging" 
                     HorizontalAlignment="Left"
                     Style="{StaticResource TitleStringText}"/>
             </Grid>

--- a/FulcrumInjector/FulcrumViewContent/Views/InjectorOptionViews/FulcrumSessionReportingView.xaml.cs
+++ b/FulcrumInjector/FulcrumViewContent/Views/InjectorOptionViews/FulcrumSessionReportingView.xaml.cs
@@ -58,6 +58,10 @@ namespace FulcrumInjector.FulcrumViewContent.Views.InjectorOptionViews
             this.ViewModel.SetupViewControl(this);
             this.DataContext = this.ViewModel;
 
+            // Append new session log files.
+            this.ViewModel.AppendSessionLogFiles();
+            this.ViewLogger.WriteLog("STORED SESSION LOG FILES INTO EMAIL ATTACHMENTS OK!", LogType.InfoLog);
+
             // Force show help menu and build email temp text
             if (this.EmailBodyTextContent.Text.Length == 0) {
                 this.EmailBodyTextContent.Text = ValueLoaders.GetConfigValue<string>("FulcrumInjectorConstants.InjectorEmailConfiguration.DefaultEmailBodyText");

--- a/FulcrumInjector/Properties/AssemblyInfo.cs
+++ b/FulcrumInjector/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Resources;
 [assembly: Guid("8cb7e832-9e90-4820-b225-0a4d59e6c0a2")]
 
 // Version information
-[assembly: AssemblyVersion("2.21.34.1392")]
-[assembly: AssemblyFileVersion("2.21.34.1392")]
+[assembly: AssemblyVersion("2.21.34.1401")]
+[assembly: AssemblyFileVersion("2.21.34.1401")]
 [assembly: NeutralResourcesLanguageAttribute( "en-US" )]
 

--- a/FulcrumShim/FulcrumShim.cpp
+++ b/FulcrumShim/FulcrumShim.cpp
@@ -84,7 +84,7 @@ BOOL CFulcrumShim::InitInstance()
 	// std::thread([this] { CFulcrumShim::StartupPipes(); });
 
 	// Build our pipes and return passed
-		// Build config app path value here and run the injector application
+	// Build config app path value here and run the injector application
 #if _DEBUG
 	TCHAR szPath[MAX_PATH]; CString ConfigAppPath;
 	SHGetFolderPath(NULL, CSIDL_PROFILE, NULL, 0, szPath);
@@ -100,6 +100,8 @@ BOOL CFulcrumShim::InitInstance()
 	ZeroMemory(&StartupInfos, sizeof(StartupInfos));
 	StartupInfos.cb = sizeof(StartupInfos);
 	ZeroMemory(&ProcessInfos, sizeof(ProcessInfos));
+	
+	// Build a new process and store values of it. Close handles to avoid memory leaks.
 	::CreateProcess(ConfigAppPath.GetString(), NULL, NULL, NULL, FALSE, 0, NULL, NULL, &StartupInfos, &ProcessInfos);
 	CloseHandle(ProcessInfos.hProcess);	CloseHandle(ProcessInfos.hThread);
 	return TRUE;
@@ -149,11 +151,12 @@ void CFulcrumShim::StartupPipes()
 void CFulcrumShim::ShutdownPipes()
 {
 	// Run the shutdown method
-	if (CFulcrumShim::fulcrumPiper->PipesConnected())
+	if (!CFulcrumShim::fulcrumPiper->PipesConnected()) { fulcrum_output::fulcrumDebug(_T("-->       Pipe instances were already closed!\n")); }
+	else 
 	{
+		// Close pipes one at a time and log as the close out.
 		fulcrum_output::fulcrumDebug(_T("-->       Calling pipe shutdown methods now...\n"));
 		CFulcrumShim::fulcrumPiper->ShutdownPipes();
 		fulcrum_output::fulcrumDebug(_T("-->       Pipe instances have been released OK!\n"));
 	}
-	else { fulcrum_output::fulcrumDebug(_T("-->       Pipe instances were already closed!\n")); }
 }

--- a/FulcrumShim/SelectionBox.cpp
+++ b/FulcrumShim/SelectionBox.cpp
@@ -84,9 +84,7 @@ BOOL CSelectionBox::OnInitDialog()
 	logDir.Format(_T("%s\\MEAT Inc\\FulcrumShim\\FulcrumLogs"), szPath);
 	if (CreateDirectory(logDir, NULL) || ERROR_ALREADY_EXISTS == GetLastError()) 
 		fulcrum_output::fulcrumDebug(_T("%.3fs    Log file folder exists. Skipping creation for this directory!\n"), GetTimeSinceInit());
-	else 
-		fulcrum_output::fulcrumDebug(_T("%.3fs    Built new folder for our output logs!\n"), GetTimeSinceInit());
-
+	else fulcrum_output::fulcrumDebug(_T("%.3fs    Built new folder for our output logs!\n"), GetTimeSinceInit());
 
 	// Build the log file path using the log dir above
 	CString cstrPath;
@@ -100,8 +98,9 @@ BOOL CSelectionBox::OnInitDialog()
 		LocalTime.wSecond
 	);
 
-	// Log new file name output.
+	// Log new file name output and open the selection box entry object.
 	fulcrum_output::fulcrumDebug(_T("%.3fs    Configured new log file correctly!\n"), GetTimeSinceInit());
+	fulcrum_output::fulcrumDebug(_T("%.3fs    Session Log File: %s\n"), GetTimeSinceInit(), cstrPath);
 
 	// Set information about the new output file
 	m_logfilename.SetWindowText(cstrPath);

--- a/FulcrumShim/fulcrum_cfifo.cpp
+++ b/FulcrumShim/fulcrum_cfifo.cpp
@@ -26,6 +26,7 @@
 
 // Fulcrum Resource Imports
 #include "fulcrum_cfifo.h"
+#include "FulcrumShim.h"
 
 // Puts a new entry into our log output file
 void fulcrum_cfifo::Put(LPCTSTR szMsg)
@@ -35,8 +36,8 @@ void fulcrum_cfifo::Put(LPCTSTR szMsg)
 
 	// If the string doesn't fit, start later to get the final maxSize characters
 	if (nSize > m_nSize) {
-		szMsg = &szMsg[nSize - m_nSize]; // start later, in order to get last m_nSize samples
-		nSize = m_nSize; // limit the length to the buffer's length
+		szMsg = &szMsg[nSize - m_nSize];	 // start later, in order to get last m_nSize samples
+		nSize = m_nSize;					 // limit the length to the buffer's length
 	}
 
 	// Wrap around buffer end

--- a/FulcrumShim/fulcrum_output.h
+++ b/FulcrumShim/fulcrum_output.h
@@ -26,6 +26,6 @@
 class fulcrum_output {
 public:
 	// Writes for our output target types
-	static void fulcrumDebug(LPCTSTR format, ...);
-	static void writeNewLogFile(LPCTSTR szFilename, bool fUseFileForever);
+	static void fulcrumDebug(LPCTSTR format_string, ...);
+	static void writeNewLogFile(LPCTSTR szFilename, bool in_fLogToFile);
 };

--- a/FulcrumShim/fulcrum_pipe.cpp
+++ b/FulcrumShim/fulcrum_pipe.cpp
@@ -152,40 +152,25 @@ void fulcrum_pipe::ShutdownInputPipe()
 
 
 // Writes data to our pipe streams
-void fulcrum_pipe::WriteStringOut(std::string str)
+void fulcrum_pipe::WriteStringOut(std::string msgString)
 {
-	DWORD written;
-	DWORD bytesToWrite = (DWORD)strlen(str.c_str());
-	BOOL res = WriteFile(hFulcrumWriter, str.c_str(), bytesToWrite, &written, NULL);
-
-	// Removing this for testing purposes
-	// CloseHandle(hFulcrumWriter);
+	DWORD bytesWritten;
+	DWORD bytesToWrite = (DWORD)strlen(msgString.c_str());
+	BOOL resultValue = WriteFile(hFulcrumWriter, msgString.c_str(), bytesToWrite, &bytesWritten, NULL);
 }
-void fulcrum_pipe::WriteBytesOut(byte b[], int b_len)
+void fulcrum_pipe::WriteBytesOut(byte byteValues[], int byteLength)
 {
-	DWORD written;
-	BOOL res = WriteFile(hFulcrumWriter, b, b_len, &written, NULL);
-
-	// Removing this for testing purposes
-	// CloseHandle(hFulcrumWriter);
+	DWORD bytesWritten;
+	BOOL resultValue = WriteFile(hFulcrumWriter, byteValues, byteLength, &bytesWritten, NULL);
 }
-void fulcrum_pipe::WriteUint32(unsigned int num) {
-	WriteBytesOut((byte*)&num, 4);
-
-	// Removing this for testing purposes
-	// CloseHandle(hFulcrumWriter);
+void fulcrum_pipe::WriteUint32(unsigned int writeNumber) {
+	WriteBytesOut((byte*)&writeNumber, 4);
 }
-void fulcrum_pipe::WriteUint32(unsigned int* a, unsigned int len) {
-	for (unsigned int i = 0; i < len; i++) WriteUint32(a[i]);
-
-	// Removing this for testing purposes
-	// CloseHandle(hFulcrumWriter);
+void fulcrum_pipe::WriteUint32(unsigned int* writeNumber, unsigned int uintLen) {
+	for (unsigned int i = 0; i < uintLen; i++) WriteUint32(writeNumber[i]);
 }
-void fulcrum_pipe::Writeint32(int num) {
-	WriteBytesOut((byte*)&num, 4); 
-
-	// Removing this for testing purposes
-	// CloseHandle(hFulcrumWriter);
+void fulcrum_pipe::Writeint32(int writeNumber) {
+	WriteBytesOut((byte*)&writeNumber, 4); 
 }
 
 // Reads data from our pipe streams
@@ -199,20 +184,20 @@ std::string fulcrum_pipe::ReadStringIn()
 	std::string str(read_buffer, bytes_read);
 	return str;
 }
-void fulcrum_pipe::ReadBytesIn(byte b[], int* b_len)
+void fulcrum_pipe::ReadBytesIn(byte inputByteBuffer[], int* bufferLength)
 {
 	DWORD bytes_read = 0;
-	DWORD bytes_to_read = *b_len;
+	DWORD bytes_to_read = *bufferLength;
 
 	// (01/23/18 TAB) - don't try to read 0 bytes, it might block forever if nothing is added at the other end
-	if (bytes_to_read > 0) BOOL res = ReadFile(hFulcrumReader, b, bytes_to_read, &bytes_read, NULL);
-	*b_len = bytes_read;
+	if (bytes_to_read > 0) BOOL res = ReadFile(hFulcrumReader, inputByteBuffer, bytes_to_read, &bytes_read, NULL);
+	*bufferLength = bytes_read;
 }
-void fulcrum_pipe::ReadBytes(byte b[], int num)
+void fulcrum_pipe::ReadBytes(byte inputByteBuffer[], int bufferLength)
 {
-	int bytesRead = num;
-	ReadBytesIn(b, &bytesRead);
-	if (bytesRead < num)
+	int bytesRead = bufferLength;
+	ReadBytesIn(inputByteBuffer, &bytesRead);
+	if (bytesRead < bufferLength)
 		throw& CPipeException(std::string(("not enough bytes")));
 }
 unsigned int fulcrum_pipe::ReadUint32()

--- a/FulcrumShim/fulcrum_pipe.h
+++ b/FulcrumShim/fulcrum_pipe.h
@@ -42,34 +42,39 @@ public:
 
 class fulcrum_pipe {
 public:
-	fulcrum_pipe();
-	~fulcrum_pipe();
+	// Methods for pipe object setup and shutdown.
+	fulcrum_pipe(); ~fulcrum_pipe();
+
+	// Bools for states of pipes.
+	bool InputConnected = false;
+	bool OutputConnected = false;
+
+	// Connect Pipe Routines
 	bool PipesConnected();
 	bool ConnectInputPipe();
 	bool ConnectOutputPipe();
+
+	// Shut down pipe routines.
 	void ShutdownPipes();
 	void ShutdownInputPipe();
 	void ShutdownOutputPipe();
 
 	// Writing operations
-	void WriteStringOut(std::string str);
-	void WriteBytesOut(byte b[], int b_len);
+	void Writeint32(int writeNumber);
+	void WriteStringOut(std::string msgString);
+	void WriteUint32(unsigned int writeNumber);
+	void WriteBytesOut(byte byteValues[], int byteLength);
+	void WriteUint32(unsigned int* writeNumber, unsigned int uintLen);
 
 	// Reading Operations
-	std::string ReadStringIn();
-	void ReadBytesIn(byte b[], int* b_len);
-	void ReadBytes(byte b[], int num);			
-	unsigned int ReadUint32();
 	int ReadInt32();
-	void WriteUint32(unsigned int num);
-	void WriteUint32(unsigned int* a, unsigned int len);
-	void Writeint32(int num);
-
-	// Bools for states
-	bool InputConnected = false;
-	bool OutputConnected = false;
+	unsigned int ReadUint32();
+	std::string ReadStringIn();
+	void ReadBytes(byte inputByteBuffer[], int bufferLength);
+	void ReadBytesIn(byte inputByteBuffer[], int* bufferLength);
 
 private:
+	// Pipe state values.
 	bool _pipesConnected = false;
 	HANDLE hFulcrumWriter, hFulcrumReader;
 };

--- a/FulcrumShim/res/fulcrum_shim.rc
+++ b/FulcrumShim/res/fulcrum_shim.rc
@@ -69,8 +69,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,10,12,1411
- PRODUCTVERSION 2,10,12,1411
+ FILEVERSION 2,10,14,1420
+ PRODUCTVERSION 2,10,14,1420
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -87,12 +87,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "MEAT Inc."
             VALUE "FileDescription", "FulcrumShim DLL used for debugging J2534 issues."
-            VALUE "FileVersion", "2.10.12.1411"
+            VALUE "FileVersion", "2.10.12.1420"
             VALUE "InternalName", "FulcrumShim.dll"
             VALUE "LegalCopyright", "Copyright (C) 2021 MEAT Inc."
             VALUE "OriginalFilename", "FulcrumShum.dll"
             VALUE "ProductName", "FulcrumShim"
-            VALUE "ProductVersion", "2.10.12.1411"
+            VALUE "ProductVersion", "2.10.12.1420"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
- Output is no longer cut short when showing up in the injector box. 
- Fixed some issues with formatting on the UI
- Built in V05.00 Support into the shim so it can now select version 05.00 DLLs. (These will not work yet. They're missing a TON of the method calls needed in the shim method definitions)
- Some overall speed changes to pipe output logging