### PR TITLE
Fixed an issue where log files were not viewed correctly

### DIFF
--- a/FulcrumInjector/FulcrumViewContent/ViewModels/InjectorCoreViewModels/FulcrumLogReviewViewModel.cs
+++ b/FulcrumInjector/FulcrumViewContent/ViewModels/InjectorCoreViewModels/FulcrumLogReviewViewModel.cs
@@ -322,11 +322,13 @@ namespace FulcrumInjector.FulcrumViewContent.ViewModels.InjectorCoreViewModels
                 // Save simulation object here.
                 ViewModelLogger.WriteLog("SAVING SIMULATION FILE OUTPUT NOW...", LogType.InfoLog);
                 this.SimulationFile = GeneratorBuilt.SaveSimulationFile(this.LoadedLogFile);
-                ViewModelLogger.WriteLog($"SAVED SIMULATION FILE AT PATH {this.SimulationFile} OK!", LogType.InfoLog);
+                if (this._simulationFile == "") throw new InvalidOperationException("FAILED TO FIND OUT NEW SIMULATION CONTENT!");
+                ViewModelLogger.WriteLog($"SAVED SIMULATION FILE AT PATH {this.SimulationFile} FROM INPUT EXPRESSIONS!", LogType.InfoLog);
+                ViewModelLogger.WriteLog($"BUILT A TOTAL OF {GeneratorBuilt.BuiltSimulationChannels.Length} SIM CHANNELS!", LogType.InfoLog);
                 this.ProcessingProgress = 100; this.SimulationBuilt = true;
 
                 // Toggle the viewer to show out output
-                if (!this.ToggleViewerContents(ViewerStateType.ShowingExpressions))
+                if (!this.ToggleViewerContents(ViewerStateType.ShowingSimulation))
                     throw new InvalidOperationException("FAILED TO PROCESS NEW FILE!");
 
                 // Return true at this point since it seems like we built everything correctly

--- a/FulcrumInjector/FulcrumViewContent/ViewModels/InjectorCoreViewModels/FulcrumLogReviewViewModel.cs
+++ b/FulcrumInjector/FulcrumViewContent/ViewModels/InjectorCoreViewModels/FulcrumLogReviewViewModel.cs
@@ -279,6 +279,12 @@ namespace FulcrumInjector.FulcrumViewContent.ViewModels.InjectorCoreViewModels
                 ViewModelLogger.WriteLog($"GENERATED A TOTAL OF {BuiltExpressions.Length} EXPRESSION OBJECTS!", LogType.InfoLog);
                 ViewModelLogger.WriteLog($"SAVED EXPRESSIONS TO NEW FILE OBJECT NAMED: {this._expressionsFile}!", LogType.InfoLog);
                 this.ProcessingProgress = 100; this.ExpressionsBuilt = true;
+
+                // Toggle the viewer to show out output
+                if (!this.ToggleViewerContents(ViewerStateType.ShowingExpressions))
+                    throw new InvalidOperationException("FAILED TO PROCESS NEW FILE!");
+
+                // Return true at this point since it seems like we built everything correctly
                 return true;
             }
             catch (Exception Ex)
@@ -317,10 +323,13 @@ namespace FulcrumInjector.FulcrumViewContent.ViewModels.InjectorCoreViewModels
                 ViewModelLogger.WriteLog("SAVING SIMULATION FILE OUTPUT NOW...", LogType.InfoLog);
                 this.SimulationFile = GeneratorBuilt.SaveSimulationFile(this.LoadedLogFile);
                 ViewModelLogger.WriteLog($"SAVED SIMULATION FILE AT PATH {this.SimulationFile} OK!", LogType.InfoLog);
+                this.ProcessingProgress = 100; this.SimulationBuilt = true;
 
-                // Return passed and move out of here.
-                this.ProcessingProgress = 100;
-                this.SimulationBuilt = true;
+                // Toggle the viewer to show out output
+                if (!this.ToggleViewerContents(ViewerStateType.ShowingExpressions))
+                    throw new InvalidOperationException("FAILED TO PROCESS NEW FILE!");
+
+                // Return true at this point since it seems like we built everything correctly
                 return true;
             } 
             catch (Exception BuildSimEx) 

--- a/FulcrumInjector/Properties/AssemblyInfo.cs
+++ b/FulcrumInjector/Properties/AssemblyInfo.cs
@@ -19,7 +19,7 @@ using System.Resources;
 [assembly: Guid("8cb7e832-9e90-4820-b225-0a4d59e6c0a2")]
 
 // Version information
-[assembly: AssemblyVersion("5.4.9.2112")]
-[assembly: AssemblyFileVersion("5.4.9.2112")]
+[assembly: AssemblyVersion("5.4.10.2114")]
+[assembly: AssemblyFileVersion("5.4.10.2114")]
 [assembly: NeutralResourcesLanguageAttribute( "en-US" )]
 

--- a/FulcrumShim/res/fulcrum_shim.rc
+++ b/FulcrumShim/res/fulcrum_shim.rc
@@ -69,8 +69,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,12,17,2954
- PRODUCTVERSION 2,12,17,2954
+ FILEVERSION 2,12,17,2957
+ PRODUCTVERSION 2,12,17,2957
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -87,12 +87,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "MEAT Inc."
             VALUE "FileDescription", "FulcrumShim DLL used for debugging J2534 issues."
-            VALUE "FileVersion", "2.12.17.2954"
+            VALUE "FileVersion", "2.12.17.2957"
             VALUE "InternalName", "FulcrumShim.dll"
             VALUE "LegalCopyright", "Copyright (C) 2022 MEAT Inc."
             VALUE "OriginalFilename", "FulcrumShum.dll"
             VALUE "ProductName", "FulcrumShim"
-            VALUE "ProductVersion", "2.12.17.2954"
+            VALUE "ProductVersion", "2.12.17.2957"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
Automatic tab switching is now in place for the injector log review content values and simulation output values